### PR TITLE
Added Additional exceptions

### DIFF
--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <title>TechSmith Hard Coded String Checker Sharp</title>
+    <version>$version$</version>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <iconUrl>http://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
+    <description>Finds hard coded string in C# files
+New features:
+    v 1.5.0.0 Added additional check for XML related attributes
+Breaking changes:
+
+Bugfixes:
+
+Misc:
+    </description>
+    <copyright>$copyright$</copyright>
+    <tags>CSharp Hard Coded Strings Checker Finder Fixer</tags>
+    <dependencies>
+    </dependencies> 
+  </metadata>
+</package>

--- a/HardCodedStringCheckerSharp/Program.cs
+++ b/HardCodedStringCheckerSharp/Program.cs
@@ -278,7 +278,10 @@ namespace HardCodedStringCheckerSharp
             "ContentProperty",
             "Given",
             "When",
-            "Then"
+            "Then",
+            "XmlAttribute",
+            "XmlRoot",
+            "XmlElement"
          };
 
          foreach ( string s in arrKeywords )

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.4.0.0" )]
-[assembly: AssemblyFileVersion( "1.4.0.0" )]
+[assembly: AssemblyVersion( "1.5.0.0" )]
+[assembly: AssemblyFileVersion( "1.5.0.0" )]


### PR DESCRIPTION
Added some additional exceptions to the hard coded string checker.

This code:

``` csharp
[XmlRoot( ElementName = "BootstrapperApplicationData", DataType = "string", IsNullable = true, Namespace = "http://schemas.microsoft.com/wix/2010/BootstrapperApplicationData" )]
class Blah
{
//...
}
```

Should not fail the hard-coded string check.
