### PR TITLE
Now ignoring test files by default

### DIFF
--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -44,6 +44,7 @@ namespace HardCodedStringCheckerSharp
          }
 
          bool hasChanges = false;
+
          foreach ( var file in _fileSystem.EnumerateFiles( _directory, "*.cs", SearchOption.AllDirectories ) )
             hasChanges |= MakeFixesOnFile( file, action );
 
@@ -76,6 +77,11 @@ namespace HardCodedStringCheckerSharp
          if ( fileName.ToLower().Contains( ".i." ) )
             return false;
          if ( fileName.ToLower().Contains( ".g." ) )
+            return false;
+
+         string fileNameOnly = Path.GetFileNameWithoutExtension( fileName ).ToLower();
+
+         if ( fileNameOnly.EndsWith( "test" ) || fileNameOnly.EndsWith( "tests" ) )
             return false;
 
          _commenting = false;

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -9,6 +9,7 @@
     <iconUrl>http://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
+    v 1.7.0.0 Now automatically ignores files that end with "test" or "tests"
     v 1.6.1.0 Refactoring into classes and abstractions
     v 1.6.0.0 No longer checks .Designer.cs files
     v 1.5.0.0 Added additional check for XML related attributes

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.6.1.0" )]
-[assembly: AssemblyFileVersion( "1.6.1.0" )]
+[assembly: AssemblyVersion( "1.7.0.0" )]
+[assembly: AssemblyFileVersion( "1.7.0.0" )]


### PR DESCRIPTION
Skips any files that contain "test" in their file name. This has been nagging us for a while, but has reached a breaking point with SpecFlow in UI tests. Attributes require strings, and those _can't_ be `NeverTranslate()`'d, because attribute string parameters can't use methods.

Seemed like a good time to ignore all test-related files.