### PR TITLE
Feature/add true to fail on errors option

### DIFF
--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -37,7 +37,7 @@ namespace HardCodedStringCheckerSharp
 
          bool failOnErrors = argsCount == 3 && 
 				(string.Equals(args[2], "--FailOnHCS") ||
-				 string.Equals(args[2], "True", StringComparison.OrdinalIgnoreCase) ||
+				 string.Equals(args[2], "True", StringComparison.OrdinalIgnoreCase)
 				);
 
          if ( !_fileSystem.DirectoryExists( _directory ) )

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -26,7 +26,7 @@ namespace HardCodedStringCheckerSharp
          int argsCount = args.Length;
          if ( argsCount != 2 && argsCount != 3 )
          {
-            _consoleAdapter.WriteLine( "Usage: <Program> RepoDirectory (Report or Fix) (--FailOnHCS optional)" );
+            _consoleAdapter.WriteLine( "Usage: <Program> RepoDirectory (Report or Fix) (--FailOnHCS or True optional)" );
             return 1;
          }
 
@@ -35,7 +35,10 @@ namespace HardCodedStringCheckerSharp
          if ( args[1] == "Fix" )
             action = Action.FixHCS;
 
-         bool failOnErrors = argsCount == 3 && args[2] == "--FailOnHCS";
+         bool failOnErrors = argsCount == 3 && 
+				(string.Equals(args[2], "--FailOnHCS") ||
+				 string.Equals(args[2], "True", StringComparison.OrdinalIgnoreCase) ||
+				);
 
          if ( !_fileSystem.DirectoryExists( _directory ) )
          {

--- a/StringCheckerLocalTester.ps1
+++ b/StringCheckerLocalTester.ps1
@@ -1,0 +1,60 @@
+#Change the directories to the proper locations. These assume repos are checked into C:\Source\
+
+$HCS = "C:\Source\Tools-Windows-Build-HardCodedStringCheckerSharp\HardCodedStringCheckerSharp\bin\Debug\HardCodedStringCheckerSharp.exe"
+$repo = "C:\Source\DotNetCommon-Windows-FileSystemUI"
+
+echo "--FailOnHCS"
+&$HCS $repo Report --FailOnHCS
+if ($LASTEXITCODE -ne 0){
+	$FailOnHCS = "fail"
+} else {$FailOnHCS = "Pass"}
+
+echo "True"
+&$HCS $repo Report True 
+if ($LASTEXITCODE -ne 0){
+	$Initialcap = "fail"
+} else {$Initialcap = "Pass"}
+
+echo "TRUE"
+&$HCS $repo Report TRUE
+if ($LASTEXITCODE -ne 0){ 
+	$allCap = "fail"
+} else {$allCap = "Pass"}
+
+echo "true"
+&$HCS $repo Report true 
+if ($LASTEXITCODE -ne 0){ 
+	$lowercase = "fail"
+} else {$lowercase = "Pass"}
+
+echo "TrUe"
+&$HCS $repo Report TrUe
+if ($LASTEXITCODE -ne 0){ 
+	$camelCase = "fail"
+} else {$camelCase = "Pass"}
+
+echo "false"
+&$HCS $repo Report false
+if ($LASTEXITCODE -ne 0){ 
+	$falseflag = "fail"
+} else {$falseflag = "Pass"}
+
+echo "Batman"
+&$HCS $repo Report Batman
+if ($LASTEXITCODE -ne 0){ 
+	$batman = "fail"
+} else {$batman = "nana nana nana nana"}
+echo ""
+echo ""
+echo "    TEST RESULTS    "
+
+echo "FailOnHCS = $FailOnHCS. Expected fail."
+echo "True = $Initialcap. Expected fail."
+echo "TRUE = $allCap. Expected fail."
+echo "true = $lowercase. Expected fail."
+echo "TrUe = $camelCase. Expected fail."
+echo ""
+echo "false = $falseflag. Expected pass."
+echo "Batman = $batman. Expected nana nana nana nana."
+echo ""
+echo ""


### PR DESCRIPTION
I ran this locally with several values and it works as expected.
The goal was to get the program to accept a True value in addition to --FailOnHCS because TeamCity is using a False option. Bethany suggested this as a matter of consistency and logical thought processes.