### PR TITLE
Adjust one comparison to ignore all .feature.cs files

### DIFF
--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -65,7 +65,7 @@ namespace HardCodedStringCheckerSharp
             return false;
          if ( fileName.Contains( ".Designer.cs" ) )
             return false;
-         if ( fileName.CompareTo( "SmokeTest.feature.cs" ) == 0 )//This is "automatically" generated
+         if ( fileName.EndsWith( ".feature.cs" ) ) //This is "automatically" generated
             return false;
 
          if ( file.ToLower().Contains( "packages" ) )

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -9,6 +9,7 @@
     <iconUrl>http://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
+    v 2.0.0.0 Now ignores all ".feature.cs" files, used in SpecFlow/Gherkin Acceptance Tests
     v 1.7.0.0 Now automatically ignores files that end with "test" or "tests"
     v 1.6.1.0 Refactoring into classes and abstractions
     v 1.6.0.0 No longer checks .Designer.cs files

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "1.7.0.0" )]
-[assembly: AssemblyFileVersion( "1.7.0.0" )]
+[assembly: AssemblyVersion( "2.0.0.0" )]
+[assembly: AssemblyFileVersion( "2.0.0.0" )]


### PR DESCRIPTION
This way we can use SpecFlow tests and their generated files.