### PR TITLE
Ignore steps files

### DIFF
--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+namespace HardCodedStringCheckerSharp.UnitTests
+{
+   [TestClass]
+   public class AppControllerTest
+   {
+   }
+}

--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -1,10 +1,91 @@
 ﻿using System;
+using System.Text;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
 namespace HardCodedStringCheckerSharp.UnitTests
 {
    [TestClass]
    public class AppControllerTest
    {
+      [TestMethod]
+      public void ShouldProcessFile_FileIsAssemblyInfo_Ignores()
+      {
+         const string assemblyInfo = "AssemblyInfo.cs";
+         AppController.ShouldProcessFile( assemblyInfo ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsCurrentVersion_Ignores()
+      {
+         const string currentVersion = "CurrentVersion.cs";
+         AppController.ShouldProcessFile( currentVersion ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsDesignerFile_Ignores()
+      {
+         const string designerFile = ".Designer.cs";
+         AppController.ShouldProcessFile( designerFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsFeatureFile_Ignores()
+      {
+         const string designerFile = ".Designer.cs";
+         AppController.ShouldProcessFile( designerFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsPackagesFile_Ignores()
+      {
+         const string packages = "packages";
+         AppController.ShouldProcessFile( packages ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsTemporaryGeneratedFile_Ignores()
+      {
+         const string temporaryGeneratedFile = "TemporaryGeneratedFile";
+         AppController.ShouldProcessFile( temporaryGeneratedFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsiFile_Ignores()
+      {
+         const string iFile = ".i.";
+         AppController.ShouldProcessFile( iFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsgFile_Ignores()
+      {
+         const string gFile = ".g.";
+         AppController.ShouldProcessFile( gFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsTestFile_Ignores()
+      {
+         const string testFile = "SomethingTest.cs";
+         AppController.ShouldProcessFile( testFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsTestsFile_Ignores()
+      {
+         const string testsFile = "SomethingTests.cs";
+         AppController.ShouldProcessFile( testsFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileIsTypicalSourceFile_Processes()
+      {
+         const string file = "SomeFile.cs";
+         AppController.ShouldProcessFile( file ).Should().BeTrue();
+      }
+
       [TestMethod]
       public void GetEncoding_NoByteOrderMarkerReturn_DefaultsToWindows1252()
       {

--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -5,5 +5,12 @@ namespace HardCodedStringCheckerSharp.UnitTests
    [TestClass]
    public class AppControllerTest
    {
+      [TestMethod]
+      public void GetEncoding_NoByteOrderMarkerReturn_DefaultsToWindows1252()
+      {
+         var appController = new AppController( Mock.Of<IFileSystem>(), Mock.Of<IConsole>() );
+
+         appController.GetEncoding( It.IsAny<string>() ).Should().Be( Encoding.GetEncoding( "Windows-1252" ) );
+      }
    }
 }

--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -80,6 +80,13 @@ namespace HardCodedStringCheckerSharp.UnitTests
       }
 
       [TestMethod]
+      public void ShouldProcessFile_FileIsStepsFile_Ignores()
+      {
+         const string stepsFile = "Steps.cs";
+         AppController.ShouldProcessFile( stepsFile ).Should().BeFalse();
+      }
+
+      [TestMethod]
       public void ShouldProcessFile_FileIsTypicalSourceFile_Processes()
       {
          const string file = "SomeFile.cs";

--- a/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
+++ b/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
@@ -72,6 +72,12 @@
     <Compile Include="AppControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HardCodedStringCheckerSharp\HardCodedStringCheckerSharp.csproj">
+      <Project>{C92BD0E4-19F6-4F22-9C7F-26D9DAAAC663}</Project>
+      <Name>HardCodedStringCheckerSharp</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
+++ b/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
@@ -69,6 +69,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="AppControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Choose>

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -56,7 +56,7 @@ namespace HardCodedStringCheckerSharp
          return 0;
       }
 
-      private bool MakeFixesOnFile( string file, Action eAction )
+      internal static bool ShouldProcessFile( string file )
       {
          string fileName = Path.GetFileName( file );
          if ( fileName.CompareTo( "AssemblyInfo.cs" ) == 0 )
@@ -71,7 +71,7 @@ namespace HardCodedStringCheckerSharp
          if ( file.ToLower().Contains( "packages" ) )
             return false;
 
-         if ( file.ToLower().Contains( "TemporaryGeneratedFile" ) )
+         if ( file.ToLower().Contains( "temporarygeneratedfile" ) )
             return false;
 
          if ( fileName.ToLower().Contains( ".i." ) )
@@ -80,9 +80,18 @@ namespace HardCodedStringCheckerSharp
             return false;
 
          string fileNameOnly = Path.GetFileNameWithoutExtension( fileName ).ToLower();
-
          if ( fileNameOnly.EndsWith( "test" ) || fileNameOnly.EndsWith( "tests" ) )
             return false;
+
+         return true;
+      }
+
+      internal bool MakeFixesOnFile( string file, Action eAction )
+      {
+         if ( !ShouldProcessFile( file ) )
+         {
+            return false;
+         }
 
          _commenting = false;
 
@@ -104,6 +113,7 @@ namespace HardCodedStringCheckerSharp
                madeChanges = true;
                _warningCount++;
                string firstDirectory = FirstDirectory( file, _directory );
+               string fileName = Path.GetFileName( file );
                _consoleAdapter.WriteLine( $"{_warningCount}: [{firstDirectory}|{fileName}:{lineNumber}] HCS \"{originalLine.Trim()}\"" );
             }
          }

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -67,6 +67,8 @@ namespace HardCodedStringCheckerSharp
             return false;
          if ( fileName.EndsWith( ".feature.cs" ) ) //This is "automatically" generated
             return false;
+         if ( fileName.EndsWith( "Steps.cs" ) ) // Acceptance Test files, not user facing
+            return false;
 
          if ( file.ToLower().Contains( "packages" ) )
             return false;

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -228,17 +228,20 @@ namespace HardCodedStringCheckerSharp
       {
          var bom = _fileSystem.GetByteOrderMarker( filePath );
 
-         // Analyze the BOM
-         if ( bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76 )
-            return Encoding.UTF7;
-         if ( bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf )
-            return Encoding.UTF8;
-         if ( bom[0] == 0xff && bom[1] == 0xfe )
-            return Encoding.Unicode; //UTF-16LE
-         if ( bom[0] == 0xfe && bom[1] == 0xff )
-            return Encoding.BigEndianUnicode; //UTF-16BE
-         if ( bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff )
-            return Encoding.UTF32;
+         if ( bom.Length != 0 )
+         {
+            // Analyze the BOM
+            if ( bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76 )
+               return Encoding.UTF7;
+            if ( bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf )
+               return Encoding.UTF8;
+            if ( bom[0] == 0xff && bom[1] == 0xfe )
+               return Encoding.Unicode; //UTF-16LE
+            if ( bom[0] == 0xfe && bom[1] == 0xff )
+               return Encoding.BigEndianUnicode; //UTF-16BE
+            if ( bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff )
+               return Encoding.UTF32;
+         }
          return Encoding.GetEncoding( "Windows-1252" );
       }
 

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright( "Copyright © 2016-2017 TechSmith Corporation. All rights reserved." )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
+[assembly: InternalsVisibleTo( "HardCodedStringCheckerSharp.UnitTests" )]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
The branch name is a lie.

This change will ignore `.steps.cs` files, which are part of SpecFlow/Gherkin/Acceptance testing.

It also backfills tests for the other exclusions, just in case.