### PR TITLE
Add --Exclude [ExcludeFile] command line option

### DIFF
--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -96,7 +96,7 @@ namespace HardCodedStringCheckerSharp.UnitTests
       [TestMethod]
       public void GetEncoding_NoByteOrderMarkerReturn_DefaultsToWindows1252()
       {
-         var appController = new AppController( Mock.Of<IFileSystem>(), Mock.Of<IConsole>() );
+         var appController = new AppController( Mock.Of<IFileSystem>(), Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>() );
 
          appController.GetEncoding( It.IsAny<string>() ).Should().Be( Encoding.GetEncoding( "Windows-1252" ) );
       }

--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -9,94 +10,136 @@ namespace HardCodedStringCheckerSharp.UnitTests
    [TestClass]
    public class AppControllerTest
    {
+      private readonly List<string> _noExclusions = new List<string>();
+
       [TestMethod]
       public void ShouldProcessFile_FileIsAssemblyInfo_Ignores()
       {
          const string assemblyInfo = "AssemblyInfo.cs";
-         AppController.ShouldProcessFile( assemblyInfo ).Should().BeFalse();
+         AppController.ShouldProcessFile( assemblyInfo, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsCurrentVersion_Ignores()
       {
          const string currentVersion = "CurrentVersion.cs";
-         AppController.ShouldProcessFile( currentVersion ).Should().BeFalse();
+         AppController.ShouldProcessFile( currentVersion, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsDesignerFile_Ignores()
       {
          const string designerFile = ".Designer.cs";
-         AppController.ShouldProcessFile( designerFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( designerFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsFeatureFile_Ignores()
       {
          const string designerFile = ".Designer.cs";
-         AppController.ShouldProcessFile( designerFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( designerFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsPackagesFile_Ignores()
       {
          const string packages = "packages";
-         AppController.ShouldProcessFile( packages ).Should().BeFalse();
+         AppController.ShouldProcessFile( packages, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsTemporaryGeneratedFile_Ignores()
       {
          const string temporaryGeneratedFile = "TemporaryGeneratedFile";
-         AppController.ShouldProcessFile( temporaryGeneratedFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( temporaryGeneratedFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsiFile_Ignores()
       {
          const string iFile = ".i.";
-         AppController.ShouldProcessFile( iFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( iFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsgFile_Ignores()
       {
          const string gFile = ".g.";
-         AppController.ShouldProcessFile( gFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( gFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsTestFile_Ignores()
       {
          const string testFile = "SomethingTest.cs";
-         AppController.ShouldProcessFile( testFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( testFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsTestsFile_Ignores()
       {
          const string testsFile = "SomethingTests.cs";
-         AppController.ShouldProcessFile( testsFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( testsFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsStepsFile_Ignores()
       {
          const string stepsFile = "Steps.cs";
-         AppController.ShouldProcessFile( stepsFile ).Should().BeFalse();
+         AppController.ShouldProcessFile( stepsFile, _noExclusions ).Should().BeFalse();
       }
 
       [TestMethod]
       public void ShouldProcessFile_FileIsTypicalSourceFile_Processes()
       {
          const string file = "SomeFile.cs";
-         AppController.ShouldProcessFile( file ).Should().BeTrue();
+         AppController.ShouldProcessFile( file, _noExclusions ).Should().BeTrue();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileInExcludedFolder_ReturnsFalse()
+      {
+         var exclusions = new List<string> { @"C:\RepoRoot\ExcludedFolder" };
+         const string file = @"C:\RepoRoot\ExcludedFolder\SomeFile.cs";
+         AppController.ShouldProcessFile( file, exclusions ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileInSubFolderOfExcludedFolder_ReturnsFalse()
+      {
+         var exclusions = new List<string> { @"C:\RepoRoot\ExcludedFolder" };
+         const string file = @"C:\RepoRoot\ExcludedFolder\Subfolder\SomeFile.cs";
+         AppController.ShouldProcessFile( file, exclusions ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileExactMatchInExclusionsList_ReturnsFalse()
+      {
+         const string file = @"C:\RepoRoot\SomeFolder\SomeFile.cs";
+         var exclusions = new List<string> { file };
+         AppController.ShouldProcessFile( file, exclusions ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileInExclusionsListWithDifferentCase_ReturnsFalse()
+      {
+         const string file = @"C:\RepoRoot\SomeFolder\SomeFile.cs";
+         var exclusions = new List<string> { @"c:\reporoot\somefolder\somefile.cs" };
+         AppController.ShouldProcessFile( file, exclusions ).Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ShouldProcessFile_FileNotInExcludedFolder_ReturnsTrue()
+      {
+         var exclusions = new List<string> { @"C:\RepoRoot\ExcludedFolder" };
+         const string file = @"C:\RepoRoot\SomeFolder\SomeFile.cs";
+         AppController.ShouldProcessFile( file, exclusions ).Should().BeTrue();
       }
 
       [TestMethod]
       public void GetEncoding_NoByteOrderMarkerReturn_DefaultsToWindows1252()
       {
-         var appController = new AppController( Mock.Of<IFileSystem>(), Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>() );
+         var appController = new AppController( Mock.Of<IFileSystem>(), Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
 
          appController.GetEncoding( It.IsAny<string>() ).Should().Be( Encoding.GetEncoding( "Windows-1252" ) );
       }

--- a/HardCodedStringCheckerSharp.UnitTests/CommandLineParserTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/CommandLineParserTest.cs
@@ -1,0 +1,166 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HardCodedStringCheckerSharp.UnitTests
+{
+   [TestClass]
+   public class CommandLineParserTest
+   {
+      [TestMethod]
+      public void ParseCommandLine_ZeroArgs_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = new string[0];
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_OneArg_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_SecondArgIsInvalid_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Invalid" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_RepoDirectorySpecified_RepoDirectoryIsSetCorrectly()
+      {
+         var parser = new CommandLineParser();
+
+         const string repoRoot = @"C:\RepoRoot";
+         string[] args = { repoRoot, "Report" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.RepoDirectory.Should().Be( repoRoot );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_SecondArgIsFix_ActionIsFixHCS()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Fix" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Action.Should().Be( Action.FixHCS );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_SecondArgIsReport_ActionIsReportHCS()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Action.Should().Be( Action.ReportHCS );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_FailOnHCSNotSpecified_SetsFailOnHCSToFalse()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.FailOnHCS.Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_ThirdArgIsInvalid_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report", "Invalid" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_ThirdArgIsFailOnHCS_SetsFailOnHCSToTrue()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report", "--FailOnHCS" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.FailOnHCS.Should().BeTrue();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_ThirdArgIsExcludeButMissingExcludeFile_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report", "--Exclude" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_ThirdArgIsExcludeWithFourthArgExcludeFile_ReturnsExcludeFile()
+      {
+         var parser = new CommandLineParser();
+
+         string excludeFile = @"C:\Path\To\ExcludeFile.txt";
+         string[] args = { @"C:\RepoRoot", "Report", "--Exclude", excludeFile };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.ExcludeFile.Should().Be( excludeFile );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_FourthArgIsInvalid_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report", "--FailOnHCS", "Invalid" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_FourthArgIsExcludeButMissingExcludeFile_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         string[] args = { @"C:\RepoRoot", "Report", "--FailOnHCS", "--Exclude" };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_FourthArgIsExcludeWithFifthArgExcludeFile_ReturnsExcludeFile()
+      {
+         var parser = new CommandLineParser();
+
+         string excludeFile = @"C:\Path\To\ExcludeFile.txt";
+         string[] args = { @"C:\RepoRoot", "Report", "--FailOnHCS", "--Exclude", excludeFile };
+         var opts = parser.ParseCommandLine( args );
+
+         opts.ExcludeFile.Should().Be( excludeFile );
+      }
+   }
+}

--- a/HardCodedStringCheckerSharp.UnitTests/ExcludeFileParserTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/ExcludeFileParserTest.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace HardCodedStringCheckerSharp.UnitTests
+{
+   [TestClass]
+   public class ExcludeFileParserTest
+   {
+      [TestMethod]
+      public void ParseExcludeFile_FileHasCommentsAndWhitespace_ReturnsCorrectResults()
+      {
+         // Arrange
+         string folder1 = @"\Folder1\To\Exclude";
+         string folder2 = @"\Folder2\To\Exclude";
+
+         string[] excludeFileContents = new string[]
+         {
+            $"// Exclude file for C# Hard Coded String Checker",
+            $"//",
+            $"// The following directories will be excluded: ",
+            $"    ",
+            $"{folder1}",
+            $"{folder2}  // in-line comment",
+            $"  "
+         };
+
+         var mockFileSystem = new Mock<IFileSystem>();
+         mockFileSystem.Setup( mfs => mfs.ReadAllLines( It.IsAny<string>() ) ).Returns( excludeFileContents );
+
+         // Act
+         var parser = new ExcludeFileParser( mockFileSystem.Object );
+         List<string> exclusions = parser.ParseExcludeFile( "DoesNotMatter" );
+
+         // Assert
+         exclusions.Count.Should().Be( 2 );
+         exclusions[0].Should().Be( folder1 );
+         exclusions[1].Should().Be( folder2 );
+      }
+
+      [TestMethod]
+      public void PrependRepoRootDir_ExclusionsHaveLeadingBackslash_CombinesPathsCorrectly()
+      {
+         // Arrange
+         string repoRoot = @"C:\RepoRoot\";
+         var exclusions = new List<string>
+         {
+            @"\Folder1\To\Exclude",  // The leading backslash changes the behavior of Path.Combine
+            @"\Folder2\To\Exclude"
+         };
+         var expectedResult = new List<string>
+         {
+            @"C:\RepoRoot\Folder1\To\Exclude",
+            @"C:\RepoRoot\Folder2\To\Exclude"
+         };
+
+         // Act
+         var parser = new ExcludeFileParser( Mock.Of<IFileSystem>() );
+         var result = parser.PrependRepoRootDir( repoRoot, exclusions );
+
+        // Assert
+         result.Should().Equal( expectedResult );
+      }
+
+      [TestMethod]
+      public void PrependRepoRootDir_RepoRootAndExclusionsDoNotHaveLeadingBackslash_CombinesPathsCorrectly()
+      {
+         // Arrange
+         string repoRoot = @"C:\RepoRoot";
+         var exclusions = new List<string>
+         {
+            @"Folder1\To\Exclude",
+            @"Folder2\To\Exclude"
+         };
+         var expectedResult = new List<string>
+         {
+            @"C:\RepoRoot\Folder1\To\Exclude",
+            @"C:\RepoRoot\Folder2\To\Exclude"
+         };
+
+         // Act
+         var parser = new ExcludeFileParser( Mock.Of<IFileSystem>() );
+         var result = parser.PrependRepoRootDir( repoRoot, exclusions );
+
+         // Assert
+         result.Should().Equal( expectedResult );
+      }
+   }
+}

--- a/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
+++ b/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="AppControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CommandLineParserTest.cs" />
+    <Compile Include="ExcludeFileParserTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HardCodedStringCheckerSharp\HardCodedStringCheckerSharp.csproj">

--- a/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
+++ b/HardCodedStringCheckerSharp.UnitTests/HardCodedStringCheckerSharp.UnitTests.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="AppControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CommandLineParserTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HardCodedStringCheckerSharp\HardCodedStringCheckerSharp.csproj">

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -29,12 +29,27 @@ namespace HardCodedStringCheckerSharp
          _excludeFileParser = excludeFileParser;
       }
 
+      private string GetUsageString()
+      {
+         return @"
+Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]]
+
+   RepoDirectory              Required. The repo root directory. e.g. C:\src\CamtasiaWin\
+
+   Action                     Required. Must be either ""Fix"" or ""Report"".
+
+   --FailOnHCS                Optional. Return failure code if any Hard Coded String (HCS) is found.
+
+   --Exclude [ExcludeFile]    Optional. Load excluded files / folders from ExcludeFile.
+";
+      }
+
       public int Main( string[] args )
       {
          CommandLineOptions options = _commandLineParser.ParseCommandLine( args );
          if ( options == null )
          {
-            _consoleAdapter.WriteLine( "Usage: <Program> RepoDirectory (Report or Fix) (--FailOnHCS optional) (--Exclude [PathToExcludeFile] optional)" );
+            _consoleAdapter.WriteLine( GetUsageString() );
             return 1;
          }
 

--- a/HardCodedStringCheckerSharp/CommandLineOptions.cs
+++ b/HardCodedStringCheckerSharp/CommandLineOptions.cs
@@ -1,0 +1,19 @@
+﻿namespace HardCodedStringCheckerSharp
+{
+   public class CommandLineOptions
+   {
+      public CommandLineOptions()
+      {
+         // Default values
+         RepoDirectory = string.Empty;
+         Action = Action.ReportHCS;
+         FailOnHCS = false;
+         ExcludeFile = string.Empty;
+      }
+
+      public string RepoDirectory { get; set; }
+      public Action Action { get; set; }
+      public bool FailOnHCS { get; set; }
+      public string ExcludeFile { get; set; }
+   }
+}

--- a/HardCodedStringCheckerSharp/CommandLineParser.cs
+++ b/HardCodedStringCheckerSharp/CommandLineParser.cs
@@ -1,0 +1,63 @@
+﻿namespace HardCodedStringCheckerSharp
+{
+   class CommandLineParser : ICommandLineParser
+   {
+      public CommandLineOptions ParseCommandLine( string[] args )
+      {
+         // Expecting between 2 and 5 arguments
+         if ( args.Length < 2 || args.Length > 5 )
+         {
+            return null;
+         }
+
+         var opts = new CommandLineOptions();
+
+         // The first argument is assumed to be the repo directory
+         opts.RepoDirectory = args[0];
+
+         // The second argument must be "Fix" or "Report"
+         string secondArg = args[1];
+         if ( secondArg == "Fix" )
+         {
+            opts.Action = Action.FixHCS;
+         }
+         else if ( secondArg == "Report" )
+         {
+            opts.Action = Action.ReportHCS;
+         }
+         else
+         {
+            return null;
+         }
+
+         if ( args.Length >= 3 )
+         {
+            // Start at third arg (index 2) because we handled first and second args above
+            for ( int i = 2; i < args.Length; i++ )
+            {
+               if ( args[i] == "--FailOnHCS" )
+               {
+                  opts.FailOnHCS = true;
+               }
+               else if ( args[i] == "--Exclude" )
+               {
+                  // The exclude file is the next argument
+                  i = i + 1;
+                  if ( i >= args.Length )
+                  {
+                     return null;  // not enough arguments
+                  }
+                  opts.ExcludeFile = args[i];
+               }
+               else
+               {
+                  // Invalid argument encountered
+                  return null;
+               }
+            }
+         }
+
+         return opts;
+      }
+   }
+}

--- a/HardCodedStringCheckerSharp/ExcludeFileParser.cs
+++ b/HardCodedStringCheckerSharp/ExcludeFileParser.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace HardCodedStringCheckerSharp
+{
+   public class ExcludeFileParser : IExcludeFileParser
+   {
+      private readonly IFileSystem _fileSystem;
+
+      public ExcludeFileParser( IFileSystem fileSystem )
+      {
+         _fileSystem = fileSystem;
+      }
+
+      public List<string> ParseExcludeFile( string excludeFile )
+      {
+         var exclusions = new List<string>();
+
+         string[] lines = _fileSystem.ReadAllLines( excludeFile );
+         foreach( string line in lines )
+         {
+            // Strip any comments
+            string lineMinusComments = line;
+            int commentStart = line.IndexOf( "//" );
+            if ( commentStart >= 0 )
+            {
+               lineMinusComments = line.Substring( 0, commentStart );
+            }
+
+            // If there's anything left after trimming whitespace, add it as an exclusion
+            string trimmedLine = lineMinusComments.Trim();
+            if ( !string.IsNullOrWhiteSpace( trimmedLine ) )
+            {
+               exclusions.Add( trimmedLine );
+            }
+         }
+
+         return exclusions;
+      }
+
+      public List<string> PrependRepoRootDir( string repoRootDir, List<string> exclusions )
+      {
+         // Note: The Trim of the backslash is necessary because a leading backslash
+         //       on the second argument causes Path.Combine to think the second path
+         //       is a root path, and it doesn't actually combine the strings. -dro
+         return exclusions.Select( ex => Path.Combine( repoRootDir, ex.Trim('\\') ) ).ToList();
+      }
+   }
+}

--- a/HardCodedStringCheckerSharp/FileSystem.cs
+++ b/HardCodedStringCheckerSharp/FileSystem.cs
@@ -6,11 +6,17 @@ namespace HardCodedStringCheckerSharp
 {
    public class FileSystem : IFileSystem
    {
+      public bool FileExists( string path )
+         => File.Exists( path );
+
       public bool DirectoryExists( string path )
          => Directory.Exists( path );
 
       public IEnumerable<string> EnumerateFiles( string path, string searchPattern, SearchOption searchOption )
          => Directory.EnumerateFiles( path, searchPattern, searchOption );
+
+      public string[] ReadAllLines( string path )
+         => File.ReadAllLines( path );
 
       public string[] ReadAllLines( string path, Encoding encoding )
          => File.ReadAllLines( path, encoding );

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
@@ -48,6 +48,7 @@
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="CommandLineParser.cs" />
     <Compile Include="ConsoleAdapter.cs" />
+    <Compile Include="ExcludeFileParser.cs" />
     <Compile Include="FileSystem.cs" />
     <Compile Include="ICommandLineParser.cs" />
     <Compile Include="IConsole.cs" />

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="Action.cs" />
     <Compile Include="AppController.cs" />
+    <Compile Include="CommandLineOptions.cs" />
     <Compile Include="ConsoleAdapter.cs" />
     <Compile Include="FileSystem.cs" />
     <Compile Include="IConsole.cs" />

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Action.cs" />
     <Compile Include="AppController.cs" />
     <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="CommandLineParser.cs" />
     <Compile Include="ConsoleAdapter.cs" />
     <Compile Include="FileSystem.cs" />
     <Compile Include="ICommandLineParser.cs" />

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
@@ -48,6 +48,7 @@
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="ConsoleAdapter.cs" />
     <Compile Include="FileSystem.cs" />
+    <Compile Include="ICommandLineParser.cs" />
     <Compile Include="IConsole.cs" />
     <Compile Include="IFileSystem.cs" />
     <Compile Include="Program.cs" />

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.csproj
@@ -51,6 +51,7 @@
     <Compile Include="FileSystem.cs" />
     <Compile Include="ICommandLineParser.cs" />
     <Compile Include="IConsole.cs" />
+    <Compile Include="IExcludeFileParser.cs" />
     <Compile Include="IFileSystem.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -9,6 +9,7 @@
     <iconUrl>https://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
+    v 4.0.0.0 Added --Exclude [ExcludeFile] as optional command line option
     v 3.0.0.0 Now ignores all "Steps.cs" files, used in SpecFlow/Gherkin Acceptance Tests
     v 2.0.0.0 Now ignores all ".feature.cs" files, used in SpecFlow/Gherkin Acceptance Tests
     v 1.7.0.0 Now automatically ignores files that end with "test" or "tests"

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -6,7 +6,7 @@
     <version>$version$</version>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <iconUrl>http://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
+    <iconUrl>https://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
     v 3.0.0.0 Now ignores all "Steps.cs" files, used in SpecFlow/Gherkin Acceptance Tests

--- a/HardCodedStringCheckerSharp/ICommandLineParser.cs
+++ b/HardCodedStringCheckerSharp/ICommandLineParser.cs
@@ -1,0 +1,7 @@
+﻿namespace HardCodedStringCheckerSharp
+{
+   public interface ICommandLineParser
+   {
+      CommandLineOptions ParseCommandLine( string[] args );
+   }
+}

--- a/HardCodedStringCheckerSharp/IExcludeFileParser.cs
+++ b/HardCodedStringCheckerSharp/IExcludeFileParser.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace HardCodedStringCheckerSharp
+{
+   public interface IExcludeFileParser
+   {
+      List<string> ParseExcludeFile( string excludeFile );
+      List<string> PrependRepoRootDir( string repoRootDir, List<string> exclusions );
+   }
+}

--- a/HardCodedStringCheckerSharp/IFileSystem.cs
+++ b/HardCodedStringCheckerSharp/IFileSystem.cs
@@ -6,9 +6,11 @@ namespace HardCodedStringCheckerSharp
 {
    public interface IFileSystem
    {
+      bool FileExists( string path );
       bool DirectoryExists( string path );
       IEnumerable<string> EnumerateFiles( string path, string searchPattern, SearchOption searchOption );
 
+      string[] ReadAllLines( string path );
       string[] ReadAllLines( string path, Encoding encoding );
       void WriteAllText( string path, string contents, Encoding encoding );
       byte[] GetByteOrderMarker( string path );

--- a/HardCodedStringCheckerSharp/Program.cs
+++ b/HardCodedStringCheckerSharp/Program.cs
@@ -6,8 +6,9 @@
       {
          var fileSystem = new FileSystem();
          var consoleAdapter = new ConsoleAdapter();
+         var commandLineParser = new CommandLineParser();
 
-         var appController = new AppController( fileSystem, consoleAdapter );
+         var appController = new AppController( fileSystem, consoleAdapter, commandLineParser );
          return appController.Main( args );
       }
    }

--- a/HardCodedStringCheckerSharp/Program.cs
+++ b/HardCodedStringCheckerSharp/Program.cs
@@ -7,8 +7,9 @@
          var fileSystem = new FileSystem();
          var consoleAdapter = new ConsoleAdapter();
          var commandLineParser = new CommandLineParser();
+         var excludeFileParser = new ExcludeFileParser( fileSystem );
 
-         var appController = new AppController( fileSystem, consoleAdapter, commandLineParser );
+         var appController = new AppController( fileSystem, consoleAdapter, commandLineParser, excludeFileParser );
          return appController.Main( args );
       }
    }

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "3.0.0.0" )]
-[assembly: AssemblyFileVersion( "3.0.0.0" )]
+[assembly: AssemblyVersion( "4.0.0.0" )]
+[assembly: AssemblyFileVersion( "4.0.0.0" )]


### PR DESCRIPTION
While trying to add an internal C# Library tool to the CamtasiaWin repo, my continuous build failed on a hard coded string.  I thought the HCS tool would have some way to exclude files/folders.  But alas, this functionality didn't exist yet.  This PR changes that.

I've added a command line parameter (optional, for backward compatibility) so that you can specify an ExcludeFile on the command line.  The new command line usage is as follows:
```
Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]]

   RepoDirectory              Required. The repo root directory. e.g. C:\src\CamtasiaWin\

   Action                     Required. Must be either "Fix" or "Report".

   --FailOnHCS                Optional. Return failure if any Hard Coded String (HCS) is found.

   --Exclude [ExcludeFile]    Optional. Load excluded files/folders from ExcludeFile.
```

The ExcludeFile looks like this:
```
// Exclude file for C# Hard Coded String Checker
//
// Notes:
// - List one file or folder to be excluded on each line below
// - All paths below are prepended with the RepoDirectory specified on the cmd line
// - If you exclude a folder, all files and subfolders under it are excluded
// - Comments and whitespace in this file are ignored
// - Case is ignored when matching against the exclusions below
// - Wildcard matches *,? are not currently supported

\Tools\UpdateLibraryInPlace\
```

When the tool runs, it will prepend the RepoDirectory in front of each exclusion in the ExcludeFile.  Then it will perform a case-insensitive match on the start of each .cs file to see if it should be excluded.