### PR TITLE
Enforce NeverTranslate for const string

### DIFF
--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -143,5 +143,39 @@ namespace HardCodedStringCheckerSharp.UnitTests
 
          appController.GetEncoding( It.IsAny<string>() ).Should().Be( Encoding.GetEncoding( "Windows-1252" ) );
       }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithoutNeverTranslate_ReturnsFalse()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const string NotUserVisibleString = ""NotUserVisible""; // NeverTranslate
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         bool hasHardcodedStrings = appController.MakeFixesOnFile( filePath, Action.ReportHCS, new List<string>() );
+         hasHardcodedStrings.Should().BeFalse();
+      }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslate_ReturnsTrue()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const string userVisibleString = ""UserVisible"";
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         bool hasHardcodedStrings = appController.MakeFixesOnFile( filePath, Action.ReportHCS, new List<string>() );
+         hasHardcodedStrings.Should().BeTrue();
+      }
    }
 }

--- a/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/AppControllerTest.cs
@@ -145,11 +145,11 @@ namespace HardCodedStringCheckerSharp.UnitTests
       }
 
       [TestMethod]
-      public void MakeFixesOnFile_FileContainsConstStringWithoutNeverTranslate_ReturnsFalse()
+      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslate_ReturnsFalse()
       {
          const string filePath = @"someDir\someFile";
          string fileString = @"
-            public const string NotUserVisibleString = ""NotUserVisible""; // NeverTranslate
+            public const string /*NeverTranslate*/ NotUserVisibleString = ""NotUserVisible"";
          ";
 
          Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
@@ -162,7 +162,41 @@ namespace HardCodedStringCheckerSharp.UnitTests
       }
 
       [TestMethod]
-      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslate_ReturnsTrue()
+      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslateInTrailingComment_ReturnsTrue()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const string NotUserVisibleString = ""NotUserVisible""; // NeverTranslate
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         bool hasHardcodedStrings = appController.MakeFixesOnFile( filePath, Action.ReportHCS, new List<string>() );
+         hasHardcodedStrings.Should().BeTrue();
+      }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslateBeforeStringKeyword_ReturnsTrue()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const /*NeverTranslate*/ string NotUserVisibleString = ""NotUserVisible"";
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         bool hasHardcodedStrings = appController.MakeFixesOnFile( filePath, Action.ReportHCS, new List<string>() );
+         hasHardcodedStrings.Should().BeTrue();
+      }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithoutNeverTranslate_ReturnsTrue()
       {
          const string filePath = @"someDir\someFile";
          string fileString = @"
@@ -176,6 +210,48 @@ namespace HardCodedStringCheckerSharp.UnitTests
 
          bool hasHardcodedStrings = appController.MakeFixesOnFile( filePath, Action.ReportHCS, new List<string>() );
          hasHardcodedStrings.Should().BeTrue();
+      }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithoutNeverTranslateWithFixHCS_FixesNeverTranslate()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const string userVisibleString = ""UserVisible"";
+         ";
+
+         string fixedString = @"
+            public const string /*NeverTranslate*/ userVisibleString = ""UserVisible"";
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         appController.MakeFixesOnFile( filePath, Action.FixHCS, new List<string>() );
+         fileSystemMock.Verify( fsm => fsm.WriteAllText( filePath, It.Is<string>( s => s.Contains( fixedString ) ), It.IsAny<Encoding>() ), Times.Once ); 
+      }
+
+      [TestMethod]
+      public void MakeFixesOnFile_FileContainsConstStringWithNeverTranslateBeforeStringKeyword_FixesNeverTranslate()
+      {
+         const string filePath = @"someDir\someFile";
+         string fileString = @"
+            public const /*NeverTranslate*/ string userVisibleString = ""UserVisible"";
+         ";
+
+         string fixedString = @"
+            public const string /*NeverTranslate*/ userVisibleString = ""UserVisible"";
+         ";
+
+         Mock<IFileSystem> fileSystemMock = new Mock<IFileSystem>();
+         fileSystemMock.Setup( fsm => fsm.ReadAllLines( filePath, It.IsAny<Encoding>() ) ).Returns( new string[] { fileString } );
+
+         var appController = new AppController( fileSystemMock.Object, Mock.Of<IConsole>(), Mock.Of<ICommandLineParser>(), Mock.Of<IExcludeFileParser>() );
+
+         appController.MakeFixesOnFile( filePath, Action.FixHCS, new List<string>() );
+         fileSystemMock.Verify( fsm => fsm.WriteAllText( filePath, It.Is<string>( s => s.Contains( fixedString ) ), It.IsAny<Encoding>() ), Times.Once );
       }
    }
 }

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -163,14 +163,51 @@ Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]
          return madeChanges;
       }
 
+      private bool FixConstString( ref string line )
+      {
+         bool hasChanges = false;
+
+         List<string> lineItems = line.Split( ' ' ).ToList();
+         int indexOfConst = lineItems.IndexOf( "const" );
+         int indexOfString = lineItems.FindIndex( s => s.ToLower() == "string" );
+         int indexOfNeverTranslate = lineItems.IndexOf( "/*NeverTranslate*/" );
+         bool isConstString = indexOfConst != -1 && indexOfString != -1;
+         if( isConstString )
+         {
+            bool hasValidNeverTranslate = indexOfNeverTranslate == indexOfString + 1;
+            if( !hasValidNeverTranslate )
+            {
+               if( indexOfNeverTranslate != -1 )
+               {
+                  lineItems.RemoveAt( indexOfNeverTranslate );
+                  indexOfString = lineItems.FindIndex( s => s.ToLower() == "string" );
+               }
+               lineItems.Insert( indexOfString + 1, "/*NeverTranslate*/" );
+               line = string.Join( " ", lineItems );
+               hasChanges = true;
+            }
+         }
+
+         return hasChanges;
+      }
+
       private bool FixUpLine( ref string line )
       {
          if ( HasIgnoreableKeyword( line ) )
+         {
             return false;
+         }
+
+         if ( FixConstString( ref line ) )
+         {
+            return true;
+         }
 
          //Does the line have a NeverTranslate on it?
          if ( line.IndexOf( "NeverTranslate" ) >= 0 )
+         {
             return false;
+         }
 
          StringType stringType = StringType.None;
          int stringStart = -1;

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -14,7 +14,7 @@ namespace HardCodedStringCheckerSharp
       private readonly ICommandLineParser _commandLineParser;
       private readonly IExcludeFileParser _excludeFileParser;
 
-      private string _directory;
+      private string _directory = string.Empty;
       private bool _commenting;
       private int _warningCount;
 
@@ -309,7 +309,6 @@ Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]
       {
          string[] keywords =
          {
-            "const",
             "Guid",
             "TemplatePart",
             "DllImport",

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -9,6 +9,7 @@
     <iconUrl>https://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
+    v 5.0.0.0 Enforce NeverTranslate on const strings
     v 4.0.0.0 Added --Exclude [ExcludeFile] as optional command line option
     v 3.0.0.0 Now ignores all "Steps.cs" files, used in SpecFlow/Gherkin Acceptance Tests
     v 2.0.0.0 Now ignores all ".feature.cs" files, used in SpecFlow/Gherkin Acceptance Tests

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "4.0.0.0" )]
-[assembly: AssemblyFileVersion( "4.0.0.0" )]
+[assembly: AssemblyVersion( "5.0.0.0" )]
+[assembly: AssemblyFileVersion( "5.0.0.0" )]


### PR DESCRIPTION
Currently, it's possible to put a user visible string in the form of:
```c#
public const string sample = "Hello!";
```

This change requires that you now indicate specifically that this string **should not** be in the resources by added a `/*NeverTranslate*/` comment:

e.g.
```C#
public const string /*NeverTranslate*/ sample = "Hello!";
```

Note:  The code enforces the comment after the `string` keyword for consistency but there's no technical reason for that

The "fix" portion of this tool is probably not as robust as it could be, though I did use it with some small tweaks to fix the errors within Camtasia

See an example PR fixing these strings here: https://github.com/TechSmith/CamtasiaWin/pull/9696