### PR TITLE
Hardcode the Copyright in the Nuspec to work with Chocolatey

### DIFF
--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -23,7 +23,7 @@ Bugfixes:
 
 Misc:
     </description>
-    <copyright>$copyright$</copyright>
+    <copyright>Copyright © 2016-2018 TechSmith Corporation. All rights reserved</copyright>
     <tags>CSharp Hard Coded Strings Checker Finder Fixer</tags>
     <dependencies>
     </dependencies> 


### PR DESCRIPTION
Missed the change in this PR - https://github.com/TechSmith/Tools-Windows-Build-HardCodedStringCheckerSharp/pull/17