### PR TITLE
Allowing passing specific files to check

### DIFF
--- a/HardCodedStringCheckerSharp.UnitTests/CommandLineParserTest.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/CommandLineParserTest.cs
@@ -162,5 +162,67 @@ namespace HardCodedStringCheckerSharp.UnitTests
 
          opts.ExcludeFile.Should().Be( excludeFile );
       }
+
+      [TestMethod]
+      public void ParseCommandLine_PassesNoSpecificFiles_HasNoSpecificFiles()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new [] { "path", "Report" } );
+
+         options.SpecificFiles.Should().BeEmpty();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_PassFilesArgumentWithNoFiles_ReturnsNull()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new[] { "path", "Report", "--Files" } );
+
+         options.Should().BeNull();
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_PassesCSharpToInspect_RecordsThatFile()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new[] { "path", "Report", "--Files", "one.cs" } );
+
+         options.SpecificFiles.Should().HaveCount( 1 ).And.Contain( "one.cs" );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_PassesOneFileCSharpFileWithDanglingComma_RecordsThatFile()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new[] { "path", "Report", "--Files", "one.cs," } );
+
+         options.SpecificFiles.Should().HaveCount( 1 ).And.Contain( "one.cs" );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_PassesTwoCSharpFilesToInspect_RecordsBothFiles()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new[] { "path", "Report", "--Files", "one.cs,two.cs" } );
+
+         options.SpecificFiles.Should().HaveCount( 2 )
+            .And.Contain( "one.cs" )
+            .And.Contain( "two.cs" );
+      }
+
+      [TestMethod]
+      public void ParseCommandLine_PassesOneTextFile_DoesNotRecordNonCSharpFiles()
+      {
+         var parser = new CommandLineParser();
+
+         var options = parser.ParseCommandLine( new[] { "path", "Report", "--Files", "one.txt" } );
+
+         options.SpecificFiles.Should().BeEmpty();
+      }
    }
 }

--- a/HardCodedStringCheckerSharp.UnitTests/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp.UnitTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "" )]
 [assembly: AssemblyProduct( "HardCodedStringCheckerSharp.UnitTests" )]
-[assembly: AssemblyCopyright( "Copyright © 2016-2017 TechSmith Corporation. All rights reserved." )]
+[assembly: AssemblyCopyright( "Copyright © 2016-2019 TechSmith Corporation. All rights reserved." )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -76,7 +76,7 @@ Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]
 
          bool hasChanges = false;
 
-         foreach ( var file in _fileSystem.EnumerateFiles( _directory, "*.cs", SearchOption.AllDirectories ) )
+         foreach ( var file in GetFilesForProcessing( options ) )
             hasChanges |= MakeFixesOnFile( file, options.Action, exclusions );
 
          if ( options.FailOnHCS && hasChanges )
@@ -85,6 +85,16 @@ Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]
          }
 
          return 0;
+      }
+
+      private IEnumerable<string> GetFilesForProcessing( CommandLineOptions options )
+      {
+         if ( options.SpecificFiles.Any() )
+         {
+            return options.SpecificFiles;
+         }
+
+         return _fileSystem.EnumerateFiles( _directory, "*.cs", SearchOption.AllDirectories );
       }
 
       internal static bool ShouldProcessFile( string file, List<string> exclusions )

--- a/HardCodedStringCheckerSharp/AppController.cs
+++ b/HardCodedStringCheckerSharp/AppController.cs
@@ -77,7 +77,15 @@ Usage: <Program> [RepoDirectory] [Action] [--FailOnHCS] [--Exclude [ExcludeFile]
          bool hasChanges = false;
 
          foreach ( var file in GetFilesForProcessing( options ) )
+         {
+            if ( !_fileSystem.FileExists( file ) )
+            {
+               _consoleAdapter.WriteLine( $"File not found, skipping {file}" );
+               continue;
+            }
+
             hasChanges |= MakeFixesOnFile( file, options.Action, exclusions );
+         }
 
          if ( options.FailOnHCS && hasChanges )
          {

--- a/HardCodedStringCheckerSharp/CommandLineOptions.cs
+++ b/HardCodedStringCheckerSharp/CommandLineOptions.cs
@@ -5,20 +5,10 @@ namespace HardCodedStringCheckerSharp
 {
    public class CommandLineOptions
    {
-      public CommandLineOptions()
-      {
-         // Default values
-         RepoDirectory = string.Empty;
-         Action = Action.ReportHCS;
-         FailOnHCS = false;
-         ExcludeFile = string.Empty;
-         SpecificFiles = Enumerable.Empty<string>();
-      }
-
-      public string RepoDirectory { get; set; }
-      public Action Action { get; set; }
-      public bool FailOnHCS { get; set; }
-      public string ExcludeFile { get; set; }
-      public IEnumerable<string> SpecificFiles { get; set; }
+      public string RepoDirectory { get; set; } = string.Empty;
+      public Action Action { get; set; } = Action.ReportHCS;
+      public bool FailOnHCS { get; set; } = false;
+      public string ExcludeFile { get; set; } = string.Empty;
+      public IEnumerable<string> SpecificFiles { get; set; } = Enumerable.Empty<string>();
    }
 }

--- a/HardCodedStringCheckerSharp/CommandLineOptions.cs
+++ b/HardCodedStringCheckerSharp/CommandLineOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace HardCodedStringCheckerSharp
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace HardCodedStringCheckerSharp
 {
    public class CommandLineOptions
    {
@@ -9,11 +12,13 @@
          Action = Action.ReportHCS;
          FailOnHCS = false;
          ExcludeFile = string.Empty;
+         SpecificFiles = Enumerable.Empty<string>();
       }
 
       public string RepoDirectory { get; set; }
       public Action Action { get; set; }
       public bool FailOnHCS { get; set; }
       public string ExcludeFile { get; set; }
+      public IEnumerable<string> SpecificFiles { get; set; }
    }
 }

--- a/HardCodedStringCheckerSharp/CommandLineParser.cs
+++ b/HardCodedStringCheckerSharp/CommandLineParser.cs
@@ -1,4 +1,8 @@
-﻿namespace HardCodedStringCheckerSharp
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace HardCodedStringCheckerSharp
 {
    class CommandLineParser : ICommandLineParser
    {
@@ -48,6 +52,17 @@
                      return null;  // not enough arguments
                   }
                   opts.ExcludeFile = args[i];
+               }
+               else if ( args[i] == "--Files" )
+               {
+                  i++;
+                  if ( i >= args.Length )
+                  {
+                     return null;
+                  }
+                  
+                  var files = args[i].Split( new[] { "," }, StringSplitOptions.RemoveEmptyEntries );
+                  opts.SpecificFiles = files.Where( f => Path.GetExtension( f ).ToLower() == ".cs" );
                }
                else
                {

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -24,7 +24,7 @@ Bugfixes:
 
 Misc:
     </description>
-    <copyright>Copyright © 2016-2018 TechSmith Corporation. All rights reserved</copyright>
+    <copyright>Copyright © 2016-2019 TechSmith Corporation. All rights reserved</copyright>
     <tags>CSharp Hard Coded Strings Checker Finder Fixer</tags>
     <dependencies>
     </dependencies> 

--- a/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
+++ b/HardCodedStringCheckerSharp/HardCodedStringCheckerSharp.nuspec
@@ -3,12 +3,13 @@
   <metadata>
     <id>HardCodedStringCheckerSharp</id>
     <title>TechSmith Hard Coded String Checker Sharp</title>
-    <version>5.0.0.0</version>
+    <version>5.1.0.0</version>
     <authors>TechSmith</authors>
     <owners>TechSmith</owners>
     <iconUrl>https://assets.techsmith.com/Images/content/mkt-about/tsc-dl-image.png</iconUrl>
     <description>Finds hard coded string in C# files
 New features:
+    v 5.1.0.0 Added --Files [file1.cs,file2.cs,etc.] to check specific files
     v 5.0.0.0 Enforce NeverTranslate on const strings
     v 4.0.0.0 Added --Exclude [ExcludeFile] as optional command line option
     v 3.0.0.0 Now ignores all "Steps.cs" files, used in SpecFlow/Gherkin Acceptance Tests

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion( "5.0.0.0" )]
-[assembly: AssemblyFileVersion( "5.0.0.0" )]
+[assembly: AssemblyVersion( "5.1.0.0" )]
+[assembly: AssemblyFileVersion( "5.1.0.0" )]

--- a/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
+++ b/HardCodedStringCheckerSharp/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "TechSmith Corporation" )]
 [assembly: AssemblyProduct( "HardCodedStringCheckerSharp" )]
-[assembly: AssemblyCopyright( "Copyright © 2016-2018 TechSmith Corporation. All rights reserved." )]
+[assembly: AssemblyCopyright( "Copyright © 2016-2019 TechSmith Corporation. All rights reserved." )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]
 [assembly: InternalsVisibleTo( "HardCodedStringCheckerSharp.UnitTests" )]


### PR DESCRIPTION
## Overview

This change now additionally allows the `--Files` parameter to specify only a set of files to inspect. If this is omitted, the default behavior is used (inspect all the `.cs` files you can find).

I've been able to use this new functionality successfully in a pre-commit Git hook to verify that your staged C# files have no hard-coded strings in them. If they do, your commit is rejected before you can even make it. This helps hard-coded strings stay out of the remote entirely, and shortens the feedback cycle if you miss them (don't have to wait for a TeamCity build).
